### PR TITLE
style(ui): improve mobile responsiveness

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -117,7 +117,7 @@ export default function RootPage() {
 
   return (
     <div className="bg-neutral-50">
-      <div className="relative bg-blue-800 min-h-[38vh] md:min-h-[35vh] flex flex-col justify-center px-4 md:px-32">
+      <div className="hidden lg:flex relative bg-blue-800 min-h-[38vh] flex-col justify-center px-4 lg:px-32">
         <div className="flex flex-col space-y-3">
           <h1 className="text-3xl md:text-6xl font-bold text-white leading-tight">
             Philippines Emergency Hotlines
@@ -137,13 +137,13 @@ export default function RootPage() {
         </div>
       </div>
       {/* SEARCH INPUT */}
-      <div className="flex justify-center items-center px-4 md:px-32 py-6 -mt-11 relative z-10">
+      <div className="justify-center items-center px-4 py-6 z-10 lg:flex lg:px-32 lg:-mt-11 lg:relative">
         <div className="flex flex-col gap-5 w-full max-w-6xl">
           {/* TODO: Update this so that it uses the selected region and then shows its respective cities (use a state for this) */}
           {metadata ? (
-            <div className="flex flex-row items-center justify-center gap-2 sm:gap-5 px-2 sm:px-6 w-full">
+            <div className="flex flex-col align-start justify-center gap-2 sm:gap-5 px-2 sm:px-6 w-full lg:flex-row lg:items-center">
               <Select value={selectedRegion} onValueChange={handleRegionChange}>
-                <SelectTrigger className="flex-1 min-w-0 sm:flex-none sm:w-[250px] py-5 bg-white text-sm sm:text-lg font-normal border-gray-300 rounded-full">
+                <SelectTrigger className="hidden lg:flex   flex-1 min-w-0 sm:flex-none sm:w-[250px] py-5 bg-white text-sm sm:text-lg font-normal border-gray-300 rounded-full">
                   <SelectValue placeholder={`Region: ${metadata.regions[0].code}`}>
                     {selectedRegion ? `Region: ${selectedRegion}` : null}
                   </SelectValue>
@@ -160,7 +160,7 @@ export default function RootPage() {
                 value={selectedProvince || ''} // Use value instead of defaultValue
                 onValueChange={handleProvinceChange} // Add onValueChange handler
               >
-                <SelectTrigger className="flex-1 min-w-0 sm:flex-none sm:w-[250px] py-5 bg-white text-sm sm:text-lg font-normal border-gray-300 rounded-full">
+                <SelectTrigger className="hidden lg:flex flex-1 min-w-0 sm:flex-none sm:w-[250px] py-5 bg-white text-sm sm:text-lg font-normal border-gray-300 rounded-full">
                   <SelectValue placeholder="Select Province">
                     {selectedProvince ? `Region: ${selectedProvince}` : null}
                   </SelectValue>
@@ -177,7 +177,7 @@ export default function RootPage() {
                 value={selectedCity || ''} // Use value instead of defaultValue
                 onValueChange={setSelectedCity} // Add onValueChange handler
               >
-                <SelectTrigger className="flex-1 min-w-0 sm:flex-none sm:w-[250px] py-5 bg-white text-sm sm:text-lg font-normal border-gray-300 rounded-full">
+                <SelectTrigger className="flex-1 w-full bg-white text-sm font-normal border-gray-300 lg:text-lg lg:min-w-0 lg:py-5 lg:rounded-full">
                   <SelectValue placeholder={`City: ${metadata.regions[0].provinces[0].cities[0]}`}>
                     {selectedCity ? `City: ${selectedCity}` : null}
                   </SelectValue>
@@ -194,7 +194,7 @@ export default function RootPage() {
                 value={selectedHotlineType}
                 onValueChange={value => setSelectedHotlineType(value)}
               >
-                <SelectTrigger className="flex-1 min-w-0 sm:flex-none sm:w-[270px] py-5 bg-white text-sm sm:text-lg font-normal border-gray-300 rounded-full">
+                <SelectTrigger className="flex-1 w-full bg-white text-sm font-normal border-gray-300 lg:text-lg lg:min-w-0 lg:py-5 lg:rounded-full">
                   <SelectValue placeholder={`Service: ${metadata.hotlineTypes[0]}`}>
                     {selectedHotlineType ? `Type:  ${selectedHotlineType}` : null}
                   </SelectValue>
@@ -247,7 +247,7 @@ export default function RootPage() {
           )}
         </div>
       </div>
-      <div className="px-4 md:px-32">
+      <div className="px-4 lg:px-32">
         {/* HOTLINES DISPLAY */}
         <HotlinesDisplay
           hotlines={hotlines}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export default function Footer() {
   return (
-    <footer className="text-gray-900 border-t border-gray-200 px-4 md:px-32 py-10">
+    <footer className="text-gray-900 border-t border-gray-200 px-4 lg:px-32 py-10">
       <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
         {/* Brand Section */}
         <div className="md:col-span-1">

--- a/src/components/hotlines-display.tsx
+++ b/src/components/hotlines-display.tsx
@@ -105,7 +105,7 @@ const HotlinesDisplay: React.FC<HotlinesDisplayProps> = ({
   }
 
   return (
-    <div className="px-4 md:px-32 py-8">
+    <div className="px-4 lg:px-32 py-8">
       {/* Header */}
       <div className="mb-8">
         <div className="flex items-center gap-2 text-sm text-gray-600 mb-2">

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -8,7 +8,7 @@ export default function Nav() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   return (
-    <nav className="bg-white border-b border-gray-200 md:px-32 py-3">
+    <nav className="bg-white border-b border-gray-200 lg:px-32 px-4 py-3">
       <div className="flex items-center justify-between px-4 md:px-0">
         <div className="flex items-center space-x-3">
           <div className="bg-gradient-to-br from-blue-900 via-red-500 to-yellow-300 text-white w-10 h-10 rounded-lg flex items-center justify-center font-bold text-lg">


### PR DESCRIPTION
## Summary

This PR enhances the mobile and tablet responsiveness of the site by hiding non-essential UI sections and adjusting layout spacing for smaller screens.

## Changes
- Hide hero section on tablet and mobile viewports
- Adjust padding across content for better spacing on smaller screens
- Hide some filter select sections on mobile devices

## Screenshots
#### Mobile
<img width="510" height="835" alt="image" src="https://github.com/user-attachments/assets/cd1ec873-dc82-4e81-ba16-0ac2b277af7a" />
<img width="510" height="835" alt="image" src="https://github.com/user-attachments/assets/d93a71e6-e93c-4560-9563-e59058ba1420" />

#### Tablet
<img width="556" height="856" alt="image" src="https://github.com/user-attachments/assets/3d1d051d-0e84-48fb-8820-255ae600a058" />

