### PR TITLE
feat(ui): fix the UI shift when scrollbar appears

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -205,6 +205,11 @@
   * {
     @apply border-border outline-ring/50;
   }
+
+  html {
+    scrollbar-gutter: stable;
+  }
+
   body {
     @apply bg-background text-foreground;
   }
@@ -235,6 +240,7 @@ body {
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
 .scrollbar-hide {
   -ms-overflow-style: none;
   scrollbar-width: none;


### PR DESCRIPTION
## 🤔 What?
- When switching between hotline categories (e.g., All Hotlines, Emergency, Medical, etc.), the vertical scrollbar sometimes appears or disappears depending on the content height. <br> This causes a small horizontal layout shift, as the page width changes dynamically

## 🤔 Why?
- This is happening because the width of the page was changing dynamically based on the height of hotline list

## 📝 Additional Notes
- Added a CSS fix to keep the layout width stable.
## Why this helps
- Improves visual stability and user experience
- Keeps layout consistent across all categories and browsers

## 🏞️ Screenshots

- Before

https://github.com/user-attachments/assets/22487ef2-4738-4d33-8c96-cb960579f1ff


- After

https://github.com/user-attachments/assets/ab85db55-b907-40c7-8b83-8cd01eae053d

